### PR TITLE
Update repository references for rename to ably-pubsub-ruby

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-ruby
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-ruby
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Documentation

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -16,6 +16,6 @@ jobs:
       id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
-      repository-name: ably-ruby
+      repository-name: ably-pubsub-ruby
     secrets:
       ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 1. Create a branch for the release, named like `release/1.2.3` (where `1.2.3` is the new version number)
 2. Update the version number in [version.rb](./lib/ably/version.rb) and commit the change.
 3. Run [`github_changelog_generator`](https://github.com/github-changelog-generator/github-changelog-generator) to automate the update of the [CHANGELOG](./CHANGELOG.md). This may require some manual intervention, both in terms of how the command is run and how the change log file is modified. Your mileage may vary:
-   - The command you will need to run will look something like this: `github_changelog_generator -u ably -p ably-ruby --since-tag v1.2.3 --output delta.md --token $GITHUB_TOKEN_WITH_REPO_ACCESS`. Generate token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
+   - The command you will need to run will look something like this: `github_changelog_generator -u ably -p ably-pubsub-ruby --since-tag v1.2.3 --output delta.md --token $GITHUB_TOKEN_WITH_REPO_ACCESS`. Generate token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
    - Using the command above, `--output delta.md` writes changes made after `--since-tag` to a new file
    - The contents of that new file (`delta.md`) then need to be manually inserted at the top of the `CHANGELOG.md`, changing the "Unreleased" heading and linking with the current version numbers
    - Also ensure that the "Full Changelog" link points to the new version tag instead of the `HEAD`
@@ -25,7 +25,7 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 5. Ideally, run `rake doc:spec` to generate a new [spec file](./SPEC.md). Then commit these changes.
 6. Make a PR against `main`. Once the PR is approved, merge it into `main`.
 7. Add a tag to the new `main` head commit and push to origin such as `git tag v1.0.3 && git push origin v1.0.3`.
-8. Visit [https://github.com/ably/ably-ruby/tags](https://github.com/ably/ably-ruby/tags) and `Add release notes` for the release including links to the changelog entry.
+8. Visit [https://github.com/ably/ably-pubsub-ruby/tags](https://github.com/ably/ably-pubsub-ruby/tags) and `Add release notes` for the release including links to the changelog entry.
 9. Run `rake release` to publish the gem to [Rubygems](https://rubygems.org/gems/ably).
 10. Release the [REST-only library `ably-ruby-rest`](https://github.com/ably/ably-ruby-rest#release-process).
 11. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)).

--- a/INTRO.md
+++ b/INTRO.md
@@ -8,7 +8,7 @@ token authentication and publishing to a channel.
 
 **Note**: The `Ruby` Client Library SDK implements the realtime and REST interfaces as two separate libraries.
 
-The `Ruby` API references are generated from the [Ably `Ruby` Client Library SDK source code](https://github.com/ably/ably-ruby)
+The `Ruby` API references are generated from the [Ably `Ruby` Client Library SDK source code](https://github.com/ably/ably-pubsub-ruby)
 using [`yard`](https://yardoc.org/). View the [Ably docs](http://ably.com/docs/) for conceptual information on using Ably
 and for client library API references split between the [realtime](http://ably.com/docs/api/realtime-sdk)
 and [REST](http://ably.com/docs/api/rest-sdk) interfaces.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Ably Pub/Sub Ruby Header](images/rubySDK-github.png)
 [![Gem Version](https://img.shields.io/gem/v/ably?style=flat)](https://rubygems.org/gems/ably)
-[![Coverage Status](https://coveralls.io/repos/ably/ably-ruby/badge.svg)](https://coveralls.io/r/ably/ably-ruby)
-[![License](https://badgen.net/github/license/ably/ably-ruby)](https://github.com/ably/ably-ruby/blob/main/LICENSE)
+[![Coverage Status](https://coveralls.io/repos/ably/ably-pubsub-ruby/badge.svg)](https://coveralls.io/r/ably/ably-pubsub-ruby)
+[![License](https://badgen.net/github/license/ably/ably-pubsub-ruby)](https://github.com/ably/ably-pubsub-ruby/blob/main/LICENSE)
 
 ---
 
@@ -124,5 +124,5 @@ Read the [CONTRIBUTING.md](./CONTRIBUTING.md) guidelines to contribute to Ably.
 
 ## Support, feedback and troubleshooting
 
-For help or technical support, visit Ably's [support page](https://ably.com/support). You can also view the [community reported Github issues](https://github.com/ably/ably-ruby/issues) or raise one yourself.
+For help or technical support, visit Ably's [support page](https://ably.com/support). You can also view the [community reported Github issues](https://github.com/ably/ably-pubsub-ruby/issues) or raise one yourself.
 

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['lewis@lmars.net', 'matt@ably.io']
   spec.description   = %q{A Ruby client library for ably.io realtime messaging}
   spec.summary       = %q{A Ruby client library for ably.io realtime messaging implemented using EventMachine}
-  spec.homepage      = 'http://github.com/ably/ably-ruby'
+  spec.homepage      = 'https://github.com/ably/ably-pubsub-ruby'
   spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
## What

Updates every reference tied to this repository's identity ahead of the rename `ably-ruby` → `ably-pubsub-ruby`:

- `.github/workflows/docs.yml` — IAM role `ably-sdk-builds-ably-ruby` → `ably-sdk-builds-ably-pubsub-ruby` (the new role is already provisioned)
- `.github/workflows/features.yml` — `repository-name: ably-pubsub-ruby`
- `README.md` — Coveralls badge, license badge, issues link
- `CONTRIBUTING.md` — changelog-generator project flag, tags URL
- `INTRO.md` — source-code link
- `ably.gemspec` — homepage URL

## What is intentionally unchanged

- The `ably-ruby/<version>` agent identifier — that is a registered identifier, not a repository reference.
- Historical CHANGELOG/UPDATING entries and issue links in code comments and specs — GitHub's rename redirect covers all of them, and rewriting history entries is churn.

## ⚠️ Merge order

**Merge immediately after the repository is renamed, not before.** The new IAM role's OIDC trust is bound to the new repository name, so the `docs.yml` change only works post-rename (and the old role name stops matching once the rename happens — hence same-window). After merging here, merge `main` into `integration/v2`, which carries identical `docs.yml`/`features.yml` copies.

Post-merge verification: full `check.yml` matrix, a `features.yml` run, and a `docs.yml` run confirming the AWS credential step succeeds **and the upload lands** (that failure mode is silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)